### PR TITLE
Fixed getting the primary key of the custom user model

### DIFF
--- a/async_messages/__init__.py
+++ b/async_messages/__init__.py
@@ -45,4 +45,4 @@ def get_messages(user):
 
 
 def _user_key(user):
-    return '_async_message_%d' % user.id
+    return '_async_message_%d' % user.pk


### PR DESCRIPTION
It's better to use `pk` property for getting the primory key when using the custom `User` model.
